### PR TITLE
[Experimental] Add mock contract for proving tx + receipts

### DIFF
--- a/contracts/interfaces/IAxiomExperimentalTx.sol
+++ b/contracts/interfaces/IAxiomExperimentalTx.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import "./core/IAxiomV1Verifier.sol";
+
+// The depth of the Merkle root of queries in:
+//   `keccakResponse`
+uint32 constant QUERY_MERKLE_DEPTH = 3;
+
+interface IAxiomExperimentalTx {
+    /// @notice States of an on-chain query
+    /// @param  Inactive The query has not been made or was refunded.
+    /// @param  Active The query has been requested, but not fulfilled.
+    /// @param  Fulfilled The query was successfully fulfilled.
+    enum AxiomQueryState {
+        Inactive,
+        Active,
+        Fulfilled
+    }
+
+    /// @notice Stores metadata about a query
+    /// @param  payment The ETH payment received, in wei.
+    /// @param  state The state of the query.
+    /// @param  deadlineBlockNumber The deadline (in block number) after which a refund may be granted.
+    /// @param  refundee The address funds should be returned to if the query is not fulfilled.
+    struct AxiomQueryMetadata {
+        uint256 payment;
+        AxiomQueryState state;
+        uint32 deadlineBlockNumber;
+        address payable refundee;
+    }
+
+    /// @notice Different types of queries
+    /// @param State Query for block header, account state, or account storage
+    /// @param Transaction Query for transaction fields
+    /// @param Receipt Query for transaction receipt fields
+    enum AxiomQueryType
+    // State,
+    {
+        Transaction,
+        Receipt
+    }
+
+    /// @notice Response values read from ZK proof for query.
+    /// @param  poseidonResponse Poseidon Merkle root
+    /// @param  keccakResponse Keccak Merkle root
+    /// @param  historicalMMRKeccak `keccak256(abi.encodePacked(mmr[10:]))`
+    /// @param  recentMMRKeccak `keccak256(abi.encodePacked(mmr[:10]))`
+    //  Detailed documentation on format here: https://hackmd.io/@axiom/S17K2drf2
+    //  ** `poseidonBlockResponseRow = poseidon(blockHash . blockNumber . poseidon_tree_root(block_header))`
+    //  ** `poseidonAccountResponseRow = poseidon(stateRoot . addr . poseidon_tree_root(account_state)))`
+    //  ** `mmr` is a variable length array of bytes32 containing the Merkle Mountain Range the ZK proof is proving into.
+    //     `mmr[idx]` is either `bytes32(0)` or the Merkle root of `1 << idx` block hashes.
+    //  ** `mmr` is guaranteed to have length at least `10` and at most `32`.
+    struct AxiomTxQueryResponse {
+        bytes32 poseidonResponse;
+        bytes32 keccakResponse;
+        bytes32 historicalMMRKeccak;
+        bytes32 recentMMRKeccak;
+    }
+
+    /// @notice Stores witness data for checking MMRs
+    /// @param  prevHash The `prevHash` as in `IAxiomV1State`.
+    /// @param  root The `root` as in `IAxiomV1State`.
+    /// @param  numFinal The `numFinal` as in `IAxiomV1State`.
+    /// @param  startBlockNumber The `startBlockNumber` as in `IAxiomV1State`.
+    /// @param  recentMMRPeaks Peaks of the MMR committed to in the public input `recentMMRKeccak` of the ZK proof.
+    /// @param  mmrComplementOrPeaks If `len(recentMMRPeaks) <= numFinal`, then this is a complementary MMR containing
+    ///         the complement of `recentMMRPeaks` which together with `recentMMRPeaks` forms `root`.
+    ///         If `len(recentMMRPeaks) > numFinal`, then this is the MMR peaks of the `numFinal` blockhashes commited
+    ///         to in `root`.
+    struct RecentMMRWitness {
+        bytes32 prevHash;
+        bytes32 root;
+        uint32 numFinal;
+        uint32 startBlockNumber;
+        bytes32[10] recentMMRPeaks;
+        bytes32[10] mmrComplementOrPeaks;
+    }
+
+    struct TxResponse {
+        // for app usage
+        uint32 blockNumber;
+        uint8 txType;
+        uint32 txIdx;
+        uint8 fieldIdx;
+        bytes value;
+        // for Merkle proof usage
+        uint32 leafIdx;
+        bytes32[QUERY_MERKLE_DEPTH] proof;
+    }
+
+    struct ReceiptResponse {
+        // for app usage
+        uint32 blockNumber;
+        uint32 txIdx;
+        uint8 fieldIdx;
+        uint8 logIdx;
+        bytes value;
+        // for Merkle proof usage
+        uint32 leafIdx;
+        bytes32[QUERY_MERKLE_DEPTH] proof;
+    }
+
+    /// @notice Read the set of verified query responses in Keccak form.
+    /// @param  queryType The type of query.
+    /// @param  hash `verifiedKeccakResults(keccak256(keccakBlockResponse . keccakAccountResponse . keccakStorageResponse)) == true`
+    ///         if and only if each of `keccakBlockResponse`, `keccakAccountResponse`, and `keccakStorageResponse` have been verified
+    ///         on-chain by a ZK proof.
+    function verifiedKeccakResults(AxiomQueryType queryType, bytes32 hash) external view returns (bool);
+
+    /*
+    /// @notice Read the set of verified query responses in Poseidon form.
+    /// @param  hash `verifiedPoseidonResults(keccak256(poseidonBlockResponse . poseidonAccountResponse . poseidonStorageResponse)) == true`
+    ///         if and only if each of `poseidonBlockResponse`, `poseidonAccountResponse`, and `poseidonStorageResponse` have been
+    ///         verified on-chain by a ZK proof.
+    function verifiedPoseidonResults(bytes32 hash) external view returns (bool);
+    */
+
+    /// @notice Returns the metadata associated to a query
+    /// @param  queryType The type of query.
+    /// @param  keccakResponse The hash of the query response.
+    function queries(AxiomQueryType queryType, bytes32 keccakResponse)
+        external
+        view
+        returns (uint256 payment, AxiomQueryState state, uint32 deadlineBlockNumber, address payable refundee);
+
+    /// @notice Emitted when the `AxiomV1Core` address is updated.
+    /// @param  newAddress The updated address.
+    event UpdateAxiomAddress(address newAddress);
+
+    /// @notice Emitted when the batch query verifier address is updated.
+    /// @param  newAddress The updated address.
+    event UpdateMMRVerifierAddress(address newAddress);
+
+    /// @notice Emitted when a Keccak result is recorded
+    /// @param  queryType The type of query.
+    /// @param  keccakResponse As documented in `AxiomTxQueryResponse`.
+    event KeccakResultEvent(AxiomQueryType queryType, bytes32 keccakResponse);
+
+    /// @notice Emitted when a Poseidon result is recorded
+    /// @param  queryType The type of query.
+    /// @param  poseidonResponse As documented in `AxiomTxQueryResponse`.
+    event PoseidonResultEvent(AxiomQueryType queryType, bytes32 poseidonResponse);
+
+    /// @notice Emitted when the `minQueryPrice` is updated.
+    /// @param  minQueryPrice The new `minQueryPrice`.
+    event UpdateMinQueryPrice(uint256 minQueryPrice);
+
+    /// @notice Emitted when the `maxQueryPrice` is updated.
+    /// @param  maxQueryPrice The new `maxQueryPrice`.
+    event UpdateMaxQueryPrice(uint256 maxQueryPrice);
+
+    /// @notice Emitted when the `queryDeadlineInterval` is updated.
+    /// @param  queryDeadlineInterval The new `queryDeadlineInterval`.
+    event UpdateQueryDeadlineInterval(uint32 queryDeadlineInterval);
+
+    /// @notice Emitted when a new query with off-chain data availability is requested.
+    /// @param  keccakQueryResponse The hash of the claimed query response.
+    /// @param  payment The ETH payment offered, in wei.
+    /// @param  deadlineBlockNumber The deadline block number after which a refund is possible.
+    /// @param  refundee The address of the refundee.
+    /// @param  ipfsHash A content-addressed hash on IPFS where the query spec may be found.
+    event QueryInitiatedOffchain(
+        bytes32 keccakQueryResponse, uint256 payment, uint32 deadlineBlockNumber, address refundee, bytes32 ipfsHash
+    );
+
+    /// @notice Emitted when a new transaction query with on-chain data availability is requested.
+    /// @param  keccakResponse The hash of the claimed query response.
+    /// @param  payment The ETH payment offered, in wei.
+    /// @param  deadlineBlockNumber The deadline block number after which a refund is possible.
+    /// @param  refundee The address of the refundee.
+    /// @param  queryHash The hash of the on-chain query.
+    event TxQueryInitiatedOnchain(
+        bytes32 keccakResponse, uint256 payment, uint32 deadlineBlockNumber, address refundee, bytes32 queryHash
+    );
+
+    /// @notice Emitted when a new receipt query with on-chain data availability is requested.
+    /// @param  keccakResponse The hash of the claimed query response.
+    /// @param  payment The ETH payment offered, in wei.
+    /// @param  deadlineBlockNumber The deadline block number after which a refund is possible.
+    /// @param  refundee The address of the refundee.
+    /// @param  queryHash The hash of the on-chain query.
+    event ReceiptQueryInitiatedOnchain(
+        bytes32 keccakResponse, uint256 payment, uint32 deadlineBlockNumber, address refundee, bytes32 queryHash
+    );
+
+    /// @notice Emitted when a query is fulfilled.
+    /// @param  queryType The type of query.
+    /// @param  keccakQueryResponse The hash of the query response.
+    /// @param  payment The ETH payment collected, in wei.
+    /// @param  prover The address of the prover collecting payment.
+    event QueryFulfilled(AxiomQueryType queryType, bytes32 keccakQueryResponse, uint256 payment, address prover);
+
+    /// @notice Emitted when a query is refunded.
+    /// @param  queryType The type of query.
+    /// @param  keccakQueryResponse The hash of the query response.
+    /// @param  payment The ETH payment refunded minus gas, in wei.
+    /// @param  refundee The address collecting the refund.
+    event QueryRefunded(
+        AxiomQueryType queryType,
+        bytes32 keccakQueryResponse,
+        uint256 payment,
+        uint32 deadlineBlockNumber,
+        address refundee
+    );
+
+    /// @notice Verify a query result on-chain.
+    /// @param  mmrIdx The index of the cached MMR to verify against.
+    /// @param  mmrWitness Witness data to reconcile `recentMMR` against `historicalRoots`.
+    /// @param  proof The ZK proof data.
+    /// @param  queryType The type of query.
+    function verifyResultVsMMR(
+        uint32 mmrIdx,
+        RecentMMRWitness calldata mmrWitness,
+        bytes calldata proof,
+        AxiomQueryType queryType
+    ) external;
+
+    /// @notice Request proof for transaction query with on-chain query data availability.
+    /// @param  keccakResponse The Keccak-encoded query response.
+    /// @param  refundee The address refunds should be sent to.
+    /// @param  query The serialized query.
+    function sendTxQuery(bytes32 keccakResponse, address payable refundee, bytes calldata query) external payable;
+
+    /// @notice Request proof for receipt query with on-chain query data availability.
+    /// @param  keccakResponse The Keccak-encoded query response.
+    /// @param  refundee The address refunds should be sent to.
+    /// @param  query The serialized query.
+    function sendReceiptQuery(bytes32 keccakResponse, address payable refundee, bytes calldata query)
+        external
+        payable;
+
+    /*
+    /// @notice Request proof for query with off-chain query data availability.
+    /// @param  keccakQueryResponse The Keccak-encoded query response.
+    /// @param  refundee The address refunds should be sent to.
+    /// @param  ipfsHash The IPFS hash the query should optionally be posted to.
+    function sendOffchainQuery(bytes32 keccakQueryResponse, address payable refundee, bytes32 ipfsHash)
+        external
+        payable;
+        */
+
+    /// @notice Fulfill a query request on-chain.
+    /// @param  keccakQueryResponse The hashed query response.
+    /// @param  payee The address to send payment to.
+    /// @param  mmrIdx The index of the cached MMR to verify against.
+    /// @param  mmrWitness Witness data to reconcile `recentMMR` against `historicalRoots`.
+    /// @param  proof The ZK proof data.
+    /// @param  queryType The type of query.
+    function fulfillQueryVsMMR(
+        bytes32 keccakQueryResponse,
+        address payable payee,
+        uint32 mmrIdx,
+        RecentMMRWitness calldata mmrWitness,
+        bytes calldata proof,
+        AxiomQueryType queryType
+    ) external;
+
+    /// @notice Trigger refund collection for a query after the deadline has expired.
+    /// @param  keccakQueryResponse THe hashed query response.
+    /// @param  queryType The type of query.
+    function collectRefund(bytes32 keccakQueryResponse, AxiomQueryType queryType) external;
+
+    /// @notice Checks whether an unpacked query response has already been verified.
+    /// @param  queryType The type of query.
+    /// @param  keccakResponse As documented in `AxiomTxQueryResponse`.
+    function isKeccakResultValid(AxiomQueryType queryType, bytes32 keccakResponse) external view returns (bool);
+
+    /*
+    /// @notice Checks whether an unpacked query response has already been verified.
+    /// @param  poseidonBlockResponse As documented in `AxiomMMRQueryResponse`.
+    /// @param  poseidonAccountResponse As documented in `AxiomMMRQueryResponse`.
+    /// @param  poseidonStorageResponse As documented in `AxiomMMRQueryResponse`.
+    function isPoseidonResultValid(
+        bytes32 poseidonBlockResponse,
+        bytes32 poseidonAccountResponse,
+        bytes32 poseidonStorageResponse
+    ) external view returns (bool);
+    */
+
+    /// @notice Verify transaction data against responses which have already been proven.
+    /// @param  keccakResponse As documented in `AxiomTxQueryResponse`.
+    /// @param  txResponses The list of transaction results.
+    function areTxResponsesValid(bytes32 keccakResponse, TxResponse[] calldata txResponses)
+        external
+        view
+        returns (bool);
+
+    /// @notice Verify transaction receipt data against responses which have already been proven.
+    /// @param  keccakResponse As documented in `AxiomTxQueryResponse`.
+    /// @param  receiptResponses The list of receipt results.
+    function areReceiptResponsesValid(bytes32 keccakResponse, ReceiptResponse[] calldata receiptResponses)
+        external
+        view
+        returns (bool);
+}

--- a/contracts/interfaces/IAxiomExperimentalTx.sol
+++ b/contracts/interfaces/IAxiomExperimentalTx.sol
@@ -3,10 +3,6 @@ pragma solidity 0.8.19;
 
 import "./core/IAxiomV1Verifier.sol";
 
-// The depth of the Merkle root of queries in:
-//   `keccakResponse`
-uint32 constant QUERY_MERKLE_DEPTH = 3;
-
 interface IAxiomExperimentalTx {
     /// @notice States of an on-chain query
     /// @param  Inactive The query has not been made or was refunded.
@@ -85,7 +81,7 @@ interface IAxiomExperimentalTx {
         bytes value;
         // for Merkle proof usage
         uint32 leafIdx;
-        bytes32[QUERY_MERKLE_DEPTH] proof;
+        bytes32[] proof;
     }
 
     struct ReceiptResponse {
@@ -97,7 +93,7 @@ interface IAxiomExperimentalTx {
         bytes value;
         // for Merkle proof usage
         uint32 leafIdx;
-        bytes32[QUERY_MERKLE_DEPTH] proof;
+        bytes32[] proof;
     }
 
     /// @notice Read the set of verified query responses in Keccak form.

--- a/contracts/interfaces/IAxiomExperimentalTx.sol
+++ b/contracts/interfaces/IAxiomExperimentalTx.sol
@@ -284,7 +284,7 @@ interface IAxiomExperimentalTx {
     /// @param  keccakReceiptResponse As documented in `AxiomTxQueryResponse`.
     /// @param  txResponses The list of transaction results.
     /// @param  receiptResponses The list of transaction results.
-    function areTxResponsesValid(
+    function areTxReceiptsValid(
         bytes32 keccakTxResponse,
         bytes32 keccakReceiptResponse,
         TxResponse[] calldata txResponses,
@@ -294,7 +294,7 @@ interface IAxiomExperimentalTx {
     /// @notice Verify transaction receipt data against responses which have already been proven.
     /// @param  keccakReceiptResponse As documented in `AxiomTxQueryResponse`.
     /// @param  receiptResponses The list of receipt results.
-    function areReceiptResponsesValid(bytes32 keccakReceiptResponse, ReceiptResponse[] calldata receiptResponses)
+    function areOnlyReceiptsValid(bytes32 keccakReceiptResponse, ReceiptResponse[] calldata receiptResponses)
         external
         view
         returns (bool);

--- a/contracts/interfaces/IAxiomExperimentalTx.sol
+++ b/contracts/interfaces/IAxiomExperimentalTx.sol
@@ -75,8 +75,8 @@ interface IAxiomExperimentalTx {
     struct TxResponse {
         // for app usage
         uint32 blockNumber;
-        uint8 txType;
         uint32 txIdx;
+        uint8 txType;
         uint8 fieldIdx;
         bytes value;
         // for Merkle proof usage

--- a/contracts/mock/AxiomExperimentalTxMock.sol
+++ b/contracts/mock/AxiomExperimentalTxMock.sol
@@ -235,7 +235,7 @@ contract AxiomExperimentalTxMock is IAxiomExperimentalTx, AxiomV1Access, UUPSUpg
     }
     */
 
-    function areTxResponsesValid(
+    function areTxReceiptsValid(
         bytes32 keccakTxResponse,
         bytes32 keccakReceiptResponse,
         TxResponse[] calldata txResponses,
@@ -281,7 +281,7 @@ contract AxiomExperimentalTxMock is IAxiomExperimentalTx, AxiomV1Access, UUPSUpg
         return true;
     }
 
-    function areReceiptResponsesValid(bytes32 keccakReceiptResponse, ReceiptResponse[] calldata receiptResponses)
+    function areOnlyReceiptsValid(bytes32 keccakReceiptResponse, ReceiptResponse[] calldata receiptResponses)
         external
         view
         returns (bool)

--- a/contracts/mock/AxiomExperimentalTxMock.sol
+++ b/contracts/mock/AxiomExperimentalTxMock.sol
@@ -9,7 +9,7 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {AxiomV1Access} from "../AxiomV1Access.sol";
 import {IAxiomV1State} from "../interfaces/core/IAxiomV1State.sol";
 import {IAxiomV1Verifier} from "../interfaces/core/IAxiomV1Verifier.sol";
-import {IAxiomExperimentalTx, QUERY_MERKLE_DEPTH} from "../interfaces/IAxiomExperimentalTx.sol";
+import {IAxiomExperimentalTx} from "../interfaces/IAxiomExperimentalTx.sol";
 import {MerkleTree} from "../libraries/MerkleTree.sol";
 import "../libraries/configuration/AxiomV1Configuration.sol";
 
@@ -527,7 +527,7 @@ contract AxiomExperimentalTxMock is IAxiomExperimentalTx, AxiomV1Access, UUPSUpg
     /// @param leaf The claimed leaf in the tree.
     /// @param proof The Merkle proof, where index 0 corresponds to a leaf in the tree.
     /// @param leafIdx The claimed index of the leaf in the tree, where index 0 corresponds to the leftmost leaf.
-    function isMerklePathValid(bytes32 root, bytes32 leaf, bytes32[QUERY_MERKLE_DEPTH] memory proof, uint32 leafIdx)
+    function isMerklePathValid(bytes32 root, bytes32 leaf, bytes32[] memory proof, uint32 leafIdx)
         internal
         pure
         returns (bool)

--- a/contracts/mock/AxiomExperimentalTxMock.sol
+++ b/contracts/mock/AxiomExperimentalTxMock.sol
@@ -250,8 +250,8 @@ contract AxiomExperimentalTxMock is IAxiomExperimentalTx, AxiomV1Access, UUPSUpg
             bytes32 leaf = keccak256(
                 abi.encodePacked(
                     txResponses[idx].blockNumber,
-                    txResponses[idx].txType,
                     txResponses[idx].txIdx,
+                    txResponses[idx].txType,
                     txResponses[idx].fieldIdx,
                     txResponses[idx].value
                 )

--- a/contracts/mock/AxiomExperimentalTxMock.sol
+++ b/contracts/mock/AxiomExperimentalTxMock.sol
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: MIT
+// MOCK VERSION; FOR TESTING ONLY
+pragma solidity 0.8.19;
+
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+import {AxiomV1Access} from "../AxiomV1Access.sol";
+import {IAxiomV1State} from "../interfaces/core/IAxiomV1State.sol";
+import {IAxiomV1Verifier} from "../interfaces/core/IAxiomV1Verifier.sol";
+import {IAxiomExperimentalTx, QUERY_MERKLE_DEPTH} from "../interfaces/IAxiomExperimentalTx.sol";
+import {MerkleTree} from "../libraries/MerkleTree.sol";
+import "../libraries/configuration/AxiomV1Configuration.sol";
+
+/// @title  AxiomExperimentalTxMock
+/// @notice Axiom smart contract that verifies queries into transactions and transaction receipts, WITHOUT VERIFICATION IN ZK.
+///         This contract is a mock version intended for testing purposes only.
+/// @dev    Is a UUPS upgradeable contract.
+contract AxiomExperimentalTxMock is IAxiomExperimentalTx, AxiomV1Access, UUPSUpgradeable {
+    using Address for address payable;
+
+    address public axiomAddress; // address of deployed AxiomV1 contract
+
+    mapping(AxiomQueryType => mapping(bytes32 => bool)) public verifiedKeccakResults;
+    // mapping(AxiomQueryType => mapping(bytes32 => bool)) public verifiedPoseidonResults;
+
+    uint256 public minQueryPrice;
+    uint256 public maxQueryPrice;
+    uint32 public queryDeadlineInterval;
+    mapping(AxiomQueryType => mapping(bytes32 => AxiomQueryMetadata)) public queries;
+
+    error BlockHashNotValidatedInCache();
+    error BlockMerkleRootDoesNotMatchProof();
+    error ProofVerificationFailed();
+    error MMRProofVerificationFailed();
+    error MMREndBlockNotRecent();
+    error BlockHashWitnessNotRecent();
+    error ClaimedMMRDoesNotMatchRecent();
+
+    error HistoricalMMRKeccakDoesNotMatchProof();
+    error KeccakQueryResponseDoesNotMatchProof();
+
+    error QueryNotInactive();
+    error PriceNotPaid();
+    error PriceTooHigh();
+    error CannotRefundIfNotActive();
+    error CannotRefundBeforeDeadline();
+    error CannotFulfillIfNotActive();
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    /// @notice Prevents the implementation contract from being initialized outside of the upgradeable proxy.
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(
+        address _axiomAddress,
+        uint256 _minQueryPrice,
+        uint256 _maxQueryPrice,
+        uint32 _queryDeadlineInterval,
+        address timelock,
+        address guardian,
+        address prover
+    ) public initializer {
+        __UUPSUpgradeable_init();
+        __AxiomV1Access_init_unchained();
+
+        require(_axiomAddress != address(0), "AxiomV1Query: Axiom address is zero");
+        require(timelock != address(0), "AxiomV1Query: timelock address is zero");
+        require(guardian != address(0), "AxiomV1Query: guardian address is zero");
+        require(prover != address(0), "AxiomV1Query: prover address is zero");
+
+        axiomAddress = _axiomAddress;
+        emit UpdateAxiomAddress(_axiomAddress);
+
+        minQueryPrice = _minQueryPrice;
+        maxQueryPrice = _maxQueryPrice;
+        queryDeadlineInterval = _queryDeadlineInterval;
+        emit UpdateMinQueryPrice(_minQueryPrice);
+        emit UpdateMaxQueryPrice(_maxQueryPrice);
+        emit UpdateQueryDeadlineInterval(_queryDeadlineInterval);
+
+        // prover is initialized to the contract deployer
+        _grantRole(PROVER_ROLE, prover);
+        _grantRole(DEFAULT_ADMIN_ROLE, timelock);
+        _grantRole(TIMELOCK_ROLE, timelock);
+        _grantRole(GUARDIAN_ROLE, guardian);
+    }
+
+    /// @notice Updates the address of the AxiomV1Core contract used to validate blockhashes, governed by a 'timelock'.
+    /// @param  _axiomAddress the new address
+    function updateAxiomAddress(address _axiomAddress) external onlyRole(TIMELOCK_ROLE) {
+        axiomAddress = _axiomAddress;
+        emit UpdateAxiomAddress(_axiomAddress);
+    }
+
+    /// @notice Set the price of a query, governed by a 'timelock'.
+    /// @param  _minQueryPrice query price in wei
+    function updateMinQueryPrice(uint256 _minQueryPrice) external onlyRole(TIMELOCK_ROLE) {
+        minQueryPrice = _minQueryPrice;
+        emit UpdateMinQueryPrice(_minQueryPrice);
+    }
+
+    /// @notice Set the price of a query, governed by a 'timelock'.
+    /// @param  _maxQueryPrice query price in wei
+    function updateMaxQueryPrice(uint256 _maxQueryPrice) external onlyRole(TIMELOCK_ROLE) {
+        maxQueryPrice = _maxQueryPrice;
+        emit UpdateMaxQueryPrice(_maxQueryPrice);
+    }
+
+    /// @notice Set the query deadline interval, governed by a 'timelock'.
+    /// @param  _queryDeadlineInterval interval in blocks
+    function updateQueryDeadlineInterval(uint32 _queryDeadlineInterval) external onlyRole(TIMELOCK_ROLE) {
+        queryDeadlineInterval = _queryDeadlineInterval;
+        emit UpdateQueryDeadlineInterval(_queryDeadlineInterval);
+    }
+
+    function verifyResultVsMMR(
+        uint32 mmrIdx,
+        RecentMMRWitness calldata mmrWitness,
+        bytes calldata proof,
+        AxiomQueryType queryType
+    ) external onlyProver {
+        requireNotFrozen();
+        _verifyResultVsMMR(mmrIdx, mmrWitness, proof, queryType);
+    }
+
+    function sendTxQuery(bytes32 keccakResponse, address payable refundee, bytes calldata query) external payable {
+        requireNotFrozen();
+        // Check for minimum payment
+        if (msg.value < minQueryPrice) {
+            revert PriceNotPaid();
+        }
+        // Check for maximum payment
+        if (msg.value > maxQueryPrice) {
+            revert PriceTooHigh();
+        }
+        _sendQuery(AxiomQueryType.Transaction, keccakResponse, msg.value, refundee);
+        bytes32 queryHash = keccak256(query);
+        emit TxQueryInitiatedOnchain(
+            keccakResponse, msg.value, uint32(block.number) + queryDeadlineInterval, refundee, queryHash
+        );
+    }
+
+    function sendReceiptQuery(bytes32 keccakResponse, address payable refundee, bytes calldata query)
+        external
+        payable
+    {
+        requireNotFrozen();
+        // Check for minimum payment
+        if (msg.value < minQueryPrice) {
+            revert PriceNotPaid();
+        }
+        // Check for maximum payment
+        if (msg.value > maxQueryPrice) {
+            revert PriceTooHigh();
+        }
+        _sendQuery(AxiomQueryType.Receipt, keccakResponse, msg.value, refundee);
+        bytes32 queryHash = keccak256(query);
+        emit TxQueryInitiatedOnchain(
+            keccakResponse, msg.value, uint32(block.number) + queryDeadlineInterval, refundee, queryHash
+        );
+    }
+
+    function fulfillQueryVsMMR(
+        bytes32 keccakQueryResponse,
+        address payable payee,
+        uint32 mmrIdx,
+        RecentMMRWitness calldata mmrWitness,
+        bytes calldata proof,
+        AxiomQueryType queryType
+    ) external onlyProver {
+        requireNotFrozen();
+
+        if (queries[queryType][keccakQueryResponse].state != AxiomQueryState.Active) {
+            revert CannotFulfillIfNotActive();
+        }
+
+        bytes32 proofKeccakQueryResponse = _verifyResultVsMMR(mmrIdx, mmrWitness, proof, queryType);
+
+        if (proofKeccakQueryResponse != keccakQueryResponse) {
+            revert KeccakQueryResponseDoesNotMatchProof();
+        }
+
+        AxiomQueryMetadata memory newMetadata = AxiomQueryMetadata({
+            payment: queries[queryType][keccakQueryResponse].payment,
+            state: AxiomQueryState.Fulfilled,
+            deadlineBlockNumber: queries[queryType][keccakQueryResponse].deadlineBlockNumber,
+            refundee: queries[queryType][keccakQueryResponse].refundee
+        });
+        queries[queryType][keccakQueryResponse] = newMetadata;
+
+        payee.sendValue(queries[queryType][keccakQueryResponse].payment);
+        emit QueryFulfilled(queryType, keccakQueryResponse, queries[queryType][keccakQueryResponse].payment, payee);
+    }
+
+    function collectRefund(bytes32 keccakQueryResponse, AxiomQueryType queryType) external {
+        AxiomQueryMetadata memory queryMetadata = queries[queryType][keccakQueryResponse];
+        if (queryMetadata.state != AxiomQueryState.Active) {
+            revert CannotRefundIfNotActive();
+        }
+        if (block.number <= queryMetadata.deadlineBlockNumber) {
+            revert CannotRefundBeforeDeadline();
+        }
+
+        AxiomQueryMetadata memory newMetadata = AxiomQueryMetadata({
+            payment: 0,
+            state: AxiomQueryState.Inactive,
+            deadlineBlockNumber: 0,
+            refundee: payable(address(0))
+        });
+        queries[queryType][keccakQueryResponse] = newMetadata;
+
+        queryMetadata.refundee.sendValue(queryMetadata.payment);
+        emit QueryRefunded(
+            queryType,
+            keccakQueryResponse,
+            queryMetadata.payment,
+            queryMetadata.deadlineBlockNumber,
+            queryMetadata.refundee
+        );
+    }
+
+    function isKeccakResultValid(AxiomQueryType queryType, bytes32 keccakResponse) external view returns (bool) {
+        return verifiedKeccakResults[queryType][keccakResponse];
+    }
+
+    /*
+    function isPoseidonResultValid(AxiomQueryType queryType, bytes32 poseidonResponse) external view returns (bool) {
+        return verifiedPoseidonResults[queryType][poseidonResponse];
+    }
+    */
+
+    function areTxResponsesValid(bytes32 keccakResponse, TxResponse[] calldata txResponses)
+        external
+        view
+        returns (bool)
+    {
+        if (!verifiedKeccakResults[AxiomQueryType.Transaction][keccakResponse]) {
+            return false;
+        }
+
+        for (uint32 idx = 0; idx < txResponses.length; idx++) {
+            bytes32 leaf = keccak256(
+                abi.encodePacked(
+                    txResponses[idx].blockNumber,
+                    txResponses[idx].txType,
+                    txResponses[idx].txIdx,
+                    txResponses[idx].fieldIdx,
+                    txResponses[idx].value
+                )
+            );
+            if (!isMerklePathValid(keccakResponse, leaf, txResponses[idx].proof, txResponses[idx].leafIdx)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function areReceiptResponsesValid(bytes32 keccakResponse, ReceiptResponse[] calldata receiptResponses)
+        external
+        view
+        returns (bool)
+    {
+        if (!verifiedKeccakResults[AxiomQueryType.Receipt][keccakResponse]) {
+            return false;
+        }
+
+        for (uint32 idx = 0; idx < receiptResponses.length; idx++) {
+            bytes32 leaf = keccak256(
+                abi.encodePacked(
+                    receiptResponses[idx].blockNumber,
+                    receiptResponses[idx].txIdx,
+                    receiptResponses[idx].fieldIdx,
+                    receiptResponses[idx].logIdx,
+                    receiptResponses[idx].value
+                )
+            );
+            if (!isMerklePathValid(keccakResponse, leaf, receiptResponses[idx].proof, receiptResponses[idx].leafIdx)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// @notice Record on-chain query.
+    /// @param  queryType The type of query.
+    /// @param  keccakResponse The hash of the query response.
+    /// @param  payment The payment offered, in wei.
+    /// @param  refundee The address to send any refund to.
+    function _sendQuery(AxiomQueryType queryType, bytes32 keccakResponse, uint256 payment, address payable refundee)
+        internal
+    {
+        if (queries[queryType][keccakResponse].state != AxiomQueryState.Inactive) {
+            revert QueryNotInactive();
+        }
+
+        AxiomQueryMetadata memory queryMetadata = AxiomQueryMetadata({
+            payment: payment,
+            state: AxiomQueryState.Active,
+            deadlineBlockNumber: uint32(block.number) + queryDeadlineInterval,
+            refundee: refundee
+        });
+        queries[queryType][keccakResponse] = queryMetadata;
+    }
+
+    /// @notice Verify a query result on-chain.
+    /// @param  mmrIdx The index of the cached MMR to verify against.
+    /// @param  mmrWitness Witness data to reconcile `recentMMR` against `historicalRoots`.
+    /// @param  proof The ZK proof data.
+    /// @param  queryType The type of query.
+    function _verifyResultVsMMR(
+        uint32 mmrIdx,
+        RecentMMRWitness calldata mmrWitness,
+        bytes calldata proof,
+        AxiomQueryType queryType
+    ) internal returns (bytes32) {
+        requireNotFrozen();
+        require(mmrIdx < MMR_RING_BUFFER_SIZE);
+
+        AxiomTxQueryResponse memory response = getTxQueryData(proof);
+
+        // Check that the historical MMR matches a cached value in `mmrRingBuffer`
+        if (IAxiomV1State(axiomAddress).mmrRingBuffer(mmrIdx) != response.historicalMMRKeccak) {
+            revert HistoricalMMRKeccakDoesNotMatchProof();
+        }
+
+        // recentMMRKeccak = keccak(mmr[0] . mmr[1] . ... . mmr[9]), where mmr[idx] is either bytes32(0) or the Merkle root of 2 ** idx hashes
+        // historicalRoots(startBlockNumber) = keccak256(prevHash . root . numFinal)
+        //         - root is the keccak Merkle root of hash(i) for i in [0, 1024), where
+        //             hash(i) is the blockhash of block `startBlockNumber + i` if i < numFinal,
+        //             hash(i) = bytes32(0x0) if i >= numFinal
+        // We check that `recentMMRPeaks` is included in `historicalRoots[startBlockNumber].root` via `mmrComplementOrPeaks`
+        // This proves that all block hashes committed to in `recentMMRPeaks` are part of the canonical chain.
+        {
+            bytes32 historicalRoot = IAxiomV1State(axiomAddress).historicalRoots(mmrWitness.startBlockNumber);
+            require(
+                historicalRoot == keccak256(abi.encodePacked(mmrWitness.prevHash, mmrWitness.root, mmrWitness.numFinal))
+            );
+        }
+
+        require(response.recentMMRKeccak == keccak256(abi.encodePacked(mmrWitness.recentMMRPeaks)));
+        uint32 mmrLen = 0;
+        for (uint32 idx = 0; idx < 10; idx++) {
+            if (mmrWitness.recentMMRPeaks[idx] != bytes32(0)) {
+                mmrLen = mmrLen + uint32(1 << idx);
+            }
+        }
+
+        // if `mmrLen == 0`, there is no check necessary against blocks
+        if (mmrLen > 0 && mmrLen <= mmrWitness.numFinal) {
+            // In this case, the full `mmrWitness` should be committed to in `mmrWitness.root`
+            // In this branch, `mmrWitness.mmrComplementOrPeaks` holds the complementary MMR which completes `mmrWitness`
+            // We check that
+            //    * The MMR in `mmrWitness` can be completed to `mmrWitness.root`
+            // This proves that the MMR in `mmrWitness` is the MMR of authentic block hashes with 0's appended.
+            // Under the random oracle assumption, 0 can never be achieved as keccak of an erroenous block header,
+            // so there is no soundness risk here.
+            (bytes32 runningHash,) = getMMRComplementRoot(mmrWitness.recentMMRPeaks, mmrWitness.mmrComplementOrPeaks);
+            require(mmrWitness.root == runningHash);
+        } else if (mmrLen > mmrWitness.numFinal) {
+            // Some of the claimed block hashes in `mmrWitness` were not committed to in `mmrWitness`
+            // In this branch, `mmrWitness.mmrComplementOrPeaks` holds the MMR values of the non-zero hashes in `root`
+            // We check that
+            //    * block hashes for numbers [startBlockNumber + numFinal, startBlockNumber + mmrLen) are recent
+            //    * appending these block hashes to the committed MMR in `mmrWitness` (without 0-padding) yields the MMR in `mmrWitness`
+            if (mmrWitness.startBlockNumber + mmrLen > block.number) {
+                revert MMREndBlockNotRecent();
+            }
+            if (mmrWitness.startBlockNumber + mmrWitness.numFinal < block.number - 256) {
+                revert BlockHashWitnessNotRecent();
+            }
+
+            // zeroHashes[idx] is the Merkle root of a tree of depth idx with 0's as leaves
+            bytes32[10] memory zeroHashes = [
+                bytes32(0x0000000000000000000000000000000000000000000000000000000000000000),
+                bytes32(0xad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5),
+                bytes32(0xb4c11951957c6f8f642c4af61cd6b24640fec6dc7fc607ee8206a99e92410d30),
+                bytes32(0x21ddb9a356815c3fac1026b6dec5df3124afbadb485c9ba5a3e3398a04b7ba85),
+                bytes32(0xe58769b32a1beaf1ea27375a44095a0d1fb664ce2dd358e7fcbfb78c26a19344),
+                bytes32(0x0eb01ebfc9ed27500cd4dfc979272d1f0913cc9f66540d7e8005811109e1cf2d),
+                bytes32(0x887c22bd8750d34016ac3c66b5ff102dacdd73f6b014e710b51e8022af9a1968),
+                bytes32(0xffd70157e48063fc33c97a050f7f640233bf646cc98d9524c6b92bcf3ab56f83),
+                bytes32(0x9867cc5f7f196b93bae1e27e6320742445d290f2263827498b54fec539f756af),
+                bytes32(0xcefad4e508c098b9a7e1d8feb19955fb02ba9675585078710969d3440f5054e0)
+            ];
+            // read the committed MMR without zero-padding
+            (bytes32 runningHash, uint32 runningSize) =
+                getMMRComplementRoot(mmrWitness.mmrComplementOrPeaks, zeroHashes);
+            require(mmrWitness.numFinal == runningSize);
+            require(mmrWitness.root == runningHash);
+
+            // check appending to the committed MMR with recent blocks will yield the claimed MMR
+            {
+                bytes32[] memory append = new bytes32[](mmrLen - mmrWitness.numFinal);
+                for (uint32 idx = 0; idx < mmrLen - mmrWitness.numFinal; idx++) {
+                    append[idx] = blockhash(mmrWitness.startBlockNumber + mmrWitness.numFinal + idx);
+                }
+                uint32 appendLeft = mmrLen - mmrWitness.numFinal;
+                uint32 height = 0;
+                uint32 insert = 0;
+                while (appendLeft > 0) {
+                    insert = (mmrWitness.numFinal >> height) & 1;
+                    for (uint32 idx = 0; idx < (appendLeft + insert) / 2; idx++) {
+                        bytes32 left;
+                        bytes32 right;
+                        if (insert == 1) {
+                            left = (idx == 0 ? mmrWitness.mmrComplementOrPeaks[height] : append[2 * idx - 1]);
+                            right = append[2 * idx];
+                        } else {
+                            left = append[2 * idx];
+                            right = append[2 * idx + 1];
+                        }
+                        append[idx] = keccak256(abi.encodePacked(left, right));
+                    }
+                    if ((appendLeft + insert) % 2 == 1) {
+                        if (append[appendLeft - 1] != mmrWitness.recentMMRPeaks[height]) {
+                            revert ClaimedMMRDoesNotMatchRecent();
+                        }
+                    } else {
+                        // This should not be possible, but leaving this revert in for safety.
+                        if (mmrWitness.recentMMRPeaks[height] != 0) {
+                            revert ClaimedMMRDoesNotMatchRecent();
+                        }
+                    }
+                    height = height + 1;
+                    appendLeft = (appendLeft + insert) / 2;
+                }
+            }
+        }
+
+        /* MOCK VERSION; FOR TESTING ONLY -- NO ZK PROOF
+        // verify the ZKP itself
+        (bool success,) = mmrVerifierAddress.call(proof);
+        if (!success) {
+            revert MMRProofVerificationFailed();
+        }
+        */
+
+        // update the cache
+        verifiedKeccakResults[queryType][response.keccakResponse] = true;
+        // verifiedPoseidonResults[queryType][response.poseidonResponse] = true;
+        emit KeccakResultEvent(queryType, response.keccakResponse);
+        // emit PoseidonResultEvent(queryType, response.poseidonResponse);
+        return response.keccakResponse;
+    }
+
+    /// @dev    Given a non-empty MMR `mmr`, compute its `size` and the Merkle root of its completion to 1024 leaves using `mmrComplement`
+    /// @param  mmr The peaks of a MMR, where `mmr[idx]` is either `bytes32(0x0)` or the Merkle root of a tree of depth `idx`.
+    ///         At least one peak is guaranteed to be non-zero.
+    /// @param  mmrComplement Entries which contain peaks of a complementary MMR, where `mmrComplement[idx]` is either `bytes32(0x0)` or the
+    ///         Merkle root of a tree of depth `idx`.  Only the relevant indices are accessed.
+    /// @dev    As an example, if `mmr` has peaks of depth 9 8 6 3, then `mmrComplement` has peaks of depth 3 4 5 7
+    ///         In this example, the peaks of `mmr` are Merkle roots of the first 2^9 leaves, then the next 2^8 leaves, and so on.
+    ///         The peaks of `mmrComplement` are Merkle roots of the first 2^3 leaves after `mmr`, then the next 2^4 leaves, and so on.
+    /// @return root The Merkle root of the completion of `mmr`.
+    /// @return size The number of leaves contained in `mmr`.
+    function getMMRComplementRoot(bytes32[10] memory mmr, bytes32[10] memory mmrComplement)
+        internal
+        pure
+        returns (bytes32 root, uint32 size)
+    {
+        bool started = false;
+        root = bytes32(0x0);
+        size = 0;
+        for (uint32 peakIdx = 0; peakIdx < 10; peakIdx++) {
+            if (!started && mmr[peakIdx] != bytes32(0x0)) {
+                root = mmrComplement[peakIdx];
+                started = true;
+            }
+            if (started) {
+                if (mmr[peakIdx] != bytes32(0x0)) {
+                    root = keccak256(abi.encodePacked(mmr[peakIdx], root));
+                    size = size + uint32(1 << peakIdx);
+                } else {
+                    root = keccak256(abi.encodePacked(root, mmrComplement[peakIdx]));
+                }
+            }
+        }
+    }
+
+    /// @dev   Verify a Merkle inclusion proof into a Merkle tree with (1 << proof.length) leaves
+    /// @param root The Merkle root.
+    /// @param leaf The claimed leaf in the tree.
+    /// @param proof The Merkle proof, where index 0 corresponds to a leaf in the tree.
+    /// @param leafIdx The claimed index of the leaf in the tree, where index 0 corresponds to the leftmost leaf.
+    function isMerklePathValid(bytes32 root, bytes32 leaf, bytes32[QUERY_MERKLE_DEPTH] memory proof, uint32 leafIdx)
+        internal
+        pure
+        returns (bool)
+    {
+        bytes32 runningHash = leaf;
+        for (uint32 idx = 0; idx < proof.length; idx++) {
+            if ((leafIdx >> idx) & 1 == 0) {
+                runningHash = keccak256(abi.encodePacked(runningHash, proof[idx]));
+            } else {
+                runningHash = keccak256(abi.encodePacked(proof[idx], runningHash));
+            }
+        }
+        return (root == runningHash);
+    }
+
+    /// @dev   Extract public instances from proof.
+    /// @param proof The ZK proof.
+    // The public instances are laid out in the proof calldata as follows:
+    //   ** First 4 * 3 * 32 = 384 bytes are reserved for proof verification data used with the pairing precompile
+    //   ** The next blocks of 13 groups of 32 bytes each are:
+    //   ** `poseidonResponse`            as a field element
+    //   ** `keccakResponse`              as 2 field elements, in hi-lo form
+    //   ** `historicalMMRKeccak` which is `keccak256(abi.encodePacked(mmr[10:]))` as 2 field elements in hi-lo form.
+    //   ** `recentMMRKeccak`     which is `keccak256(abi.encodePacked(mmr[:10]))` as 2 field elements in hi-lo form.
+    // Here:
+    //   ** `{keccak, poseidon}Response` are defined as in `AxiomTxQueryResponse`.
+    //   ** hi-lo form means a uint256 `(a << 128) + b` is represented as two uint256's `a` and `b`, each of which is
+    //      guaranteed to contain a uint128.
+    //   ** `mmr` is a variable length array of bytes32 containing the Merkle Mountain Range that `proof` is proving into.
+    //      `mmr[idx]` is either `bytes32(0)` or the Merkle root of `1 << idx` block hashes.
+    //   ** `mmr` is guaranteed to have length at least `10` and at most `32`.
+    function getTxQueryData(bytes calldata proof) internal pure returns (AxiomTxQueryResponse memory) {
+        return AxiomTxQueryResponse({
+            poseidonResponse: bytes32(proof[384:384 + 32]),
+            keccakResponse: bytes32(
+                uint256(bytes32(proof[384 + 32:384 + 2 * 32])) << 128 | uint256(bytes32(proof[384 + 2 * 32:384 + 3 * 32]))
+                ),
+            historicalMMRKeccak: bytes32(
+                uint256(bytes32(proof[384 + 3 * 32:384 + 4 * 32])) << 128
+                    | uint256(bytes32(proof[384 + 4 * 32:384 + 5 * 32]))
+                ),
+            recentMMRKeccak: bytes32(
+                uint256(bytes32(proof[384 + 5 * 32:384 + 6 * 32])) << 128
+                    | uint256(bytes32(proof[384 + 6 * 32:384 + 7 * 32]))
+                )
+        });
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(AccessControlUpgradeable)
+        returns (bool)
+    {
+        return interfaceId == type(IAxiomExperimentalTx).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    function _authorizeUpgrade(address) internal override onlyRole(TIMELOCK_ROLE) {}
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[40] private __gap;
+}

--- a/contracts/mock/AxiomExperimentalTxMock.sol
+++ b/contracts/mock/AxiomExperimentalTxMock.sol
@@ -161,7 +161,7 @@ contract AxiomExperimentalTxMock is IAxiomExperimentalTx, AxiomV1Access, UUPSUpg
         }
         _sendQuery(AxiomQueryType.OnlyReceipts, keccakResponse, msg.value, refundee);
         bytes32 queryHash = keccak256(query);
-        emit TxQueryInitiatedOnchain(
+        emit ReceiptQueryInitiatedOnchain(
             keccakResponse, msg.value, uint32(block.number) + queryDeadlineInterval, refundee, queryHash
         );
     }

--- a/script/goerli/AxiomTxDeployMock.s.sol
+++ b/script/goerli/AxiomTxDeployMock.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {AxiomProxy} from "../../contracts/AxiomProxy.sol";
+import {AxiomTimelock} from "../../contracts/AxiomTimelock.sol";
+import {AxiomExperimentalTxMock} from "../../contracts/mock/AxiomExperimentalTxMock.sol";
+
+// This version currently deploys both AxiomV1 and AxiomV1Query contracts
+contract AxiomTxDeployMock is Script {
+    function run() external {
+        vm.startBroadcast();
+
+        AxiomExperimentalTxMock experimentalImplementation = new AxiomExperimentalTxMock();
+        // AxiomTimelock timelock = new AxiomTimelock(60 /* 1 minute delay */, timelockMultisig);
+        address guardian = address(0x99C7E4eB11541388535a4608C14738C24f131921);
+        address timelock = address(0xc2d7e38a40808BBfc1834C79b5Ba4b27bC4c462e);
+        address prover = address(0x8018fe32fCFd3d166E8b4c4E37105318A84BA11b);
+
+        address axiomMock = address(0x8d41105949fc6C418DfF1A76Ff5Ae69128Ade55a); // AxiomProxy of **AxiomV1Mock**
+        bytes memory init = abi.encodeWithSignature(
+            "initialize(address,uint256,uint256,uint32,address,address,address)",
+            address(axiomMock),
+            10 * 1000 * 1000 gwei, // 0.01 eth
+            2 ether,
+            7200, // queryDeadlineInterval **in blocks** [this was a typo and we put 1 day in seconds]
+            timelock,
+            guardian,
+            prover
+        );
+        console.logBytes(init);
+        new AxiomProxy(address(experimentalImplementation), init);
+        vm.stopBroadcast();
+    }
+}

--- a/script/goerli/deploy_tx_mock.sh
+++ b/script/goerli/deploy_tx_mock.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd $(git rev-parse --show-toplevel)
+source .env
+
+forge script script/goerli/AxiomTxDeployMock.s.sol:AxiomTxDeployMock --private-key $GOERLI_PRIVATE_KEY --rpc-url $GOERLI_RPC_URL --force --verify --etherscan-api-key $ETHERSCAN_API_KEY --broadcast -vvvv

--- a/script/local/AxiomTxDeployMock.s.sol
+++ b/script/local/AxiomTxDeployMock.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {AxiomProxy} from "../../contracts/AxiomProxy.sol";
+import {AxiomTimelock} from "../../contracts/AxiomTimelock.sol";
+import {AxiomExperimentalTxMock} from "../../contracts/mock/AxiomExperimentalTxMock.sol";
+
+// This version currently deploys both AxiomV1 and AxiomV1Query contracts
+contract AxiomTxDeployMock is Script {
+    function run() external {
+        vm.startBroadcast();
+
+        AxiomExperimentalTxMock queryImplementation = new AxiomExperimentalTxMock();
+        // AxiomTimelock timelock = new AxiomTimelock(60 /* 1 minute delay */, timelockMultisig);
+        address guardian = address(0x99C7E4eB11541388535a4608C14738C24f131921);
+        address timelock = address(0xc2d7e38a40808BBfc1834C79b5Ba4b27bC4c462e);
+        address prover = msg.sender;
+
+        address axiomMock = address(0x8d41105949fc6C418DfF1A76Ff5Ae69128Ade55a); // AxiomProxy of **AxiomV1Mock**
+        bytes memory queryInit = abi.encodeWithSignature(
+            "initialize(address,uint256,uint256,uint32,address,address,address)",
+            address(axiomMock),
+            10 * 1000 * 1000 gwei, // 0.01 eth
+            2 ether,
+            7200, // queryDeadlineInterval **in blocks** [this was a typo and we put 1 day in seconds]
+            timelock,
+            guardian,
+            prover
+        );
+        console.logBytes(queryInit);
+        new AxiomProxy(address(queryImplementation), queryInit);
+        vm.stopBroadcast();
+    }
+}

--- a/script/local/deploy_tx_mock.sh
+++ b/script/local/deploy_tx_mock.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd $(git rev-parse --show-toplevel)
+source .env
+LOCAL_RPC_URL="http://localhost:8545"
+
+cast send --private-key $ANVIL_PRIVATE_KEY $SENDER_ADDRESS --value 100ether
+forge script script/local/AxiomTxDeployMock.s.sol:AxiomTxDeployMock --sender $SENDER_ADDRESS --keystore $KEYSTORE_PATH --password $KEY_PASSWD --rpc-url $LOCAL_RPC_URL --broadcast -vvvv


### PR DESCRIPTION
New smart contract with interface for submitting queries for proofs of historical transaction and receipt data. 
- Currently this is a mock version without SNARK verifiers to showcase the interface.